### PR TITLE
Add CI workflows for build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn -B --no-transfer-progress package
+
+      - name: Upload JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: PowerBoard-jar
+          path: target/*.jar
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags: ['release-*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Verify tag matches pom.xml version
+        run: |
+          POM_VERSION=$(mvn -B -q help:evaluate -Dexpression=project.version -DforceStdout)
+          TAG_VERSION="${GITHUB_REF_NAME#release-}"
+          echo "pom.xml version: $POM_VERSION"
+          echo "Tag version:     $TAG_VERSION"
+          if [ "$POM_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' does not match pom.xml version '$POM_VERSION'"
+            exit 1
+          fi
+
+      - name: Build with Maven
+        run: mvn -B --no-transfer-progress package
+
+      - name: Publish Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/*.jar
+          generate_release_notes: true
+          fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary
- Add `.github/workflows/build.yml` — builds on push/PR to `master`, uploads JAR as artifact
- Add `.github/workflows/release.yml` — triggers on `release-*` tags, verifies tag matches `pom.xml` version, builds, and attaches JAR + auto-generated release notes to the GitHub Release

## Best practices applied
- Least-privilege `permissions:` (read for build, write for release)
- Concurrency group cancels redundant PR reruns
- `setup-java@v4` with built-in Maven dependency cache
- Pinned actions to stable major versions (`@v4`, `@v2`)
- Tag/pom version mismatch fails the release early
- `name:` intentionally unset in the release action so a manually set release title isn't overwritten

## Test plan
- [ ] Push triggers `Build` workflow successfully on this PR
- [ ] JAR artifact is downloadable from the workflow run
- [ ] After merge, draft a release via GitHub UI with tag `release-X.Y.Z` (body empty) → `Release` workflow attaches JAR and fills in release notes
- [ ] Tag/pom version mismatch correctly fails the release job

🤖 Generated with [Claude Code](https://claude.com/claude-code)