### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </repository>
       <repository>
           <id>placeholderapi</id>
-          <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+          <url>https://repo.extendedclip.com/releases/</url>
       </repository>
   </repositories>
 
@@ -30,7 +30,7 @@
       <dependency>
           <groupId>net.luckperms</groupId>
           <artifactId>api</artifactId>
-          <version>5.4</version>
+          <version>5.5</version>
           <scope>provided</scope>
       </dependency>
 
@@ -38,7 +38,7 @@
       <dependency>
           <groupId>org.spigotmc</groupId>
           <artifactId>spigot-api</artifactId>
-          <version>1.20.6-R0.1-SNAPSHOT</version>
+          <version>1.21.11-R0.1-SNAPSHOT</version>
           <scope>provided</scope>
       </dependency>
       <dependency>
@@ -51,7 +51,7 @@
     <dependency>
         <groupId>com.github.MilkBowl</groupId>
         <artifactId>VaultAPI</artifactId>
-        <version>1.7</version>
+        <version>1.7.1</version>
         <scope>provided</scope>
 	    <exclusions>
 		    <exclusion>
@@ -63,7 +63,7 @@
     <dependency>
      	<groupId>me.clip</groupId>
     	<artifactId>placeholderapi</artifactId>
-        <version>2.11.1</version>
+        <version>2.12.2</version>
         <scope>provided</scope>
     </dependency>
 	<!-- present at runtime in all supported versions, but not a transient dep. of spigot-api -->
@@ -76,7 +76,7 @@
       <dependency>
           <groupId>org.jetbrains</groupId>
           <artifactId>annotations</artifactId>
-          <version>24.0.1</version>
+          <version>26.0.2</version>
           <scope>compile</scope>
       </dependency>
 
@@ -94,7 +94,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
+				<version>3.15.0</version>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>

--- a/src/main/java/de/xite/scoreboard/modules/tablist/TablistPlayer.java
+++ b/src/main/java/de/xite/scoreboard/modules/tablist/TablistPlayer.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Player;
 
 import de.xite.scoreboard.main.PowerBoard;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class TablistPlayer {
 	static PowerBoard pl = PowerBoard.pl;

--- a/src/main/java/de/xite/scoreboard/utils/Version.java
+++ b/src/main/java/de/xite/scoreboard/utils/Version.java
@@ -3,13 +3,13 @@ package de.xite.scoreboard.utils;
 import de.xite.scoreboard.main.PowerBoard;
 import org.bukkit.Bukkit;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.logging.Logger;
 
 public class Version implements Comparable<Version> {
 	private final String version;
 
-	public Version(@Nonnull String version) {
+	public Version(@NotNull String version) {
 		if(!version.matches("[0-9]+(\\.[0-9]+)*"))
 			throw new IllegalArgumentException("Invalid version format");
 		this.version = version;
@@ -59,7 +59,7 @@ public class Version implements Comparable<Version> {
 	 * int = -1: a is older than b
 	 */
 	@Override
-	public int compareTo(@Nonnull Version that) {
+	public int compareTo(@NotNull Version that) {
 		String[] thisParts = this.version.split("\\.");
 		String[] thatParts = that.version.split("\\.");
 


### PR DESCRIPTION
## Summary
Modernisiert Maven-Dependencies. Auslöser: CI-Build auf #73 failte, weil PlaceholderAPI `2.11.1` nicht mehr im Repo verfügbar ist.

## Änderungen

| Dep | alt → neu | Notiz |
|-----|-----------|-------|
| LuckPerms API | 5.4 → 5.5 | Kompatibel |
| Spigot API (modern) | 1.20.6 → 1.21.11 | Code nutzt weder `Material`-Enums noch `EntityType` — check passed |
| VaultAPI | 1.7 → 1.7.1 | Patch |
| PlaceholderAPI | 2.11.1 → 2.12.2 | Löst CI-Block; `PlaceholderExpansion`-API unverändert |
| JetBrains annotations | 24.0.1 → 26.0.2 | Compile-only |
| maven-compiler-plugin | 3.11.0 → 3.15.0 | Build-Plugin |
| PlaceholderAPI-Repo URL | `extendedclip.com/content/repositories/placeholderapi/` → `extendedclip.com/releases/` | Alte URL redirectet nur noch |

## Code-Anpassung (Folge des Spigot-Bumps)

Spigot 1.21 zieht `com.google.code.findbugs:jsr305` nicht mehr transitiv mit rein. Die drei Verwendungen von `javax.annotation.Nullable`/`Nonnull` wurden auf `org.jetbrains.annotations.Nullable`/`NotNull` umgestellt (diese Dep gab's schon im Projekt). Annotations haben `RetentionPolicy.CLASS` — **kein Runtime-Impact auf irgendeiner MC-Version**.

Betroffen:
- `TablistPlayer.java` — `@Nullable TablistManager`
- `Version.java` — `@Nonnull` → `@NotNull` an 2 Parametern

## Bewusst NICHT geändert

- `commons-io` bleibt auf **2.12.0** — alte MC-Server (1.7.10/1.8.8) bundlen eine ältere commons-io (~2.4); Bump bärge Risiko auf `NoSuchMethodError` auf legacy Versionen.
- Legacy `org.spigotmc.:spigot-api:1.12.2` bleibt unverändert (Multi-Version-Support).
- `java.version=1.8` bleibt — steuert Bytecode-Target für Alt-Server.

## Test plan
- [x] CI `Build` Workflow läuft grün
- [ ] Runtime-Test auf einem 1.7.10/1.8.8 Server (legacy-code-path)
- [ ] Runtime-Test auf einem aktuellen 1.21.x Server
- [ ] Scoreboard/Tablist-Funktionalität spot-check
- [ ] PlaceholderAPI-Platzhalter (`prefix`, `suffix`, `tps`, etc.) funktionieren weiterhin

🤖 Generated with [Claude Code](https://claude.com/claude-code)