### PR TITLE
Fix 1.7.10 compat: use org.bukkit.ChatColor

### DIFF
--- a/src/main/java/de/xite/scoreboard/commands/PowerBoardCommand.java
+++ b/src/main/java/de/xite/scoreboard/commands/PowerBoardCommand.java
@@ -13,7 +13,7 @@ import de.xite.scoreboard.main.Config;
 import de.xite.scoreboard.main.PowerBoard;
 import de.xite.scoreboard.modules.board.ScoreboardPlayer;
 import de.xite.scoreboard.utils.Updater;
-import net.md_5.bungee.api.ChatColor;
+import org.bukkit.ChatColor;
 
 public class PowerBoardCommand implements CommandExecutor, TabCompleter {
 	private static final PowerBoard instance = PowerBoard.getInstance();

--- a/src/main/java/de/xite/scoreboard/main/Config.java
+++ b/src/main/java/de/xite/scoreboard/main/Config.java
@@ -16,7 +16,7 @@ import de.xite.scoreboard.utils.Placeholders;
 import de.xite.scoreboard.utils.SelfCheck;
 import de.xite.scoreboard.utils.Teams;
 import de.xite.scoreboard.utils.UpgradeVersion;
-import net.md_5.bungee.api.ChatColor;
+import org.bukkit.ChatColor;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;

--- a/src/main/java/de/xite/scoreboard/main/PowerBoard.java
+++ b/src/main/java/de/xite/scoreboard/main/PowerBoard.java
@@ -19,7 +19,7 @@ import de.xite.scoreboard.modules.tablist.TablistPlayer;
 import de.xite.scoreboard.utils.TPSCalc;
 import de.xite.scoreboard.utils.Teams;
 import de.xite.scoreboard.utils.Updater;
-import net.md_5.bungee.api.ChatColor;
+import org.bukkit.ChatColor;
 
 import java.util.logging.Logger;
 


### PR DESCRIPTION
## Summary
`net.md_5.bungee.api.ChatColor` existiert in Spigot 1.7.10 nicht — Plugin-Load crasht mit `NoClassDefFoundError` in `PowerBoard.<clinit>`.

Alle 3 Verwendungsstellen nutzen ausschließlich Standard-Farb-Enums (GRAY, YELLOW, RED, GOLD, DARK_AQUA, DARK_GRAY, GREEN, STRIKETHROUGH). Die sind in `org.bukkit.ChatColor` genauso vorhanden, und bei String-Konkatenation produzieren beide dasselbe `§X` Color-Code-Format.

## Diff

- `PowerBoard.java`
- `PowerBoardCommand.java`
- `Config.java`

Jeweils nur der Import von `net.md_5.bungee.api.ChatColor` → `org.bukkit.ChatColor`.

## Hinweise

- Pre-existing Bug — unabhängig vom Dep-Bump-PR (#74)
- Keine RGB-`ChatColor.of(...)` Nutzungen im Code, daher 1:1 sicher
- Kein Verhaltensunterschied auf neueren MC-Versionen erwartet

## Test plan
- [x] CI `Build` läuft grün
- [ ] Runtime-Test 1.7.10 → Plugin lädt ohne `NoClassDefFoundError`
- [ ] Runtime-Test 1.8.8 → Plugin lädt, Prefix im Chat korrekt gefärbt
- [ ] Runtime-Test 1.21.x → kein Regressionsschaden, Prefix gleich

🤖 Generated with [Claude Code](https://claude.com/claude-code)