### PR TITLE
Fix version parsing for Paper 26+ and null fallback

### DIFF
--- a/src/main/java/de/xite/scoreboard/utils/Version.java
+++ b/src/main/java/de/xite/scoreboard/utils/Version.java
@@ -5,6 +5,8 @@ import org.bukkit.Bukkit;
 
 import org.jetbrains.annotations.NotNull;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Version implements Comparable<Version> {
 	private final String version;
@@ -13,29 +15,6 @@ public class Version implements Comparable<Version> {
 		if(!version.matches("[0-9]+(\\.[0-9]+)*"))
 			throw new IllegalArgumentException("Invalid version format");
 		this.version = version;
-	}
-
-	public static final Version CURRENT;
-	static {
-		Logger logger = PowerBoard.pl.getLogger();
-		Version v;
-		try {
-			String s = Bukkit.getBukkitVersion();
-			String version = s.substring(0, s.lastIndexOf("-R")).replace("_", ".");
-
-			if(PowerBoard.debug) {
-				logger.info(" ");
-				logger.info("Detected Server Version (original): " + s);
-				logger.info("Detected Server Version (extracted): " + version);
-			}
-
-			v = new Version(version);
-		} catch (Exception e) {
-			e.printStackTrace();
-			logger.severe("Could not extract MC version! Defaulting to 1.13.");
-			v = Version.v1_13;
-		}
-		CURRENT = v;
 	}
 
 	public static final Version v1_8  = new Version("1.8");
@@ -50,6 +29,36 @@ public class Version implements Comparable<Version> {
 	public static final Version v1_17 = new Version("1.17");
 	public static final Version v1_18 = new Version("1.18");
 	public static final Version v1_20_3 = new Version("1.20.3");
+
+	public static final Version CURRENT;
+	static {
+		Logger logger = PowerBoard.pl.getLogger();
+		Version v;
+		String s = Bukkit.getBukkitVersion();
+		try {
+			// Extracts the leading numeric version, tolerating arbitrary suffixes:
+			//   "1.21.4-R0.1-SNAPSHOT"   -> "1.21.4"
+			//   "26.1.2-build.12-alpha"  -> "26.1.2"
+			//   "26.1.2.build.12-alpha"  -> "26.1.2"
+			Matcher m = Pattern.compile("^([0-9]+(?:\\.[0-9]+)*)").matcher(s.replace("_", "."));
+			if(!m.find())
+				throw new IllegalArgumentException("No leading version number in '" + s + "'");
+			String version = m.group(1);
+
+			if(PowerBoard.debug) {
+				logger.info(" ");
+				logger.info("Detected Server Version (original): " + s);
+				logger.info("Detected Server Version (extracted): " + version);
+			}
+
+			v = new Version(version);
+		} catch (Exception e) {
+			e.printStackTrace();
+			logger.severe("Could not extract MC version from '" + s + "'! Defaulting to 1.13.");
+			v = Version.v1_13;
+		}
+		CURRENT = v;
+	}
 	private static boolean isAbove_1_13 = Version.CURRENT.isAtLeast(Version.v1_13);
 	private static boolean isAbove_1_20_3 = Version.CURRENT.isAtLeast(Version.v1_20_3);
 


### PR DESCRIPTION
## Summary
- `Bukkit.getBukkitVersion()` on Paper 26.1.2 no longer matches the legacy `<mc>-R<api>-SNAPSHOT` format, causing `StringIndexOutOfBoundsException` in `Version.<clinit>`. Replaced the substring parser with a regex that extracts the leading numeric version and tolerates arbitrary suffixes.
- The catch-block fallback referenced `Version.v1_13`, but the constants were declared **after** the static block — so on any parse failure `CURRENT` became `null` and the `isAbove_1_13` initializer threw `NullPointerException`. Moved the version constants above the static block so the fallback actually works.
- On failure, the original Bukkit version string is now included in the error log to aid future diagnosis.

## Test plan
- [x] Verified on Paper 26.1.2 — plugin enables and parses the version correctly
- [ ] Sanity-check on an older Paper/Spigot (e.g. 1.20.x) that the legacy format still parses